### PR TITLE
Updated init message, styled buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,20 +24,22 @@ body {
   flex-wrap: wrap;
   gap: 10px;
   justify-content: center;
+  align-items: center;
   margin-top: 20px;
 }
 
 .tag-button {
   background-color: #007bff;
   color: white;
-  border: none;
+  border: 2px solid transparent;
   padding: 5px 10px;
   border-radius: 5px;
   cursor: pointer;
 }
 
 .tag-button.selected {
-  background-color: #0056b3;
+  background-color: #004ea2;
+  border: 2px solid rgb(60, 99, 197);
 }
 
 main {
@@ -72,6 +74,25 @@ main {
 .btn-primary:hover {
   background-color: #0056b3;
 }
+
+.btn-secondary {
+  cursor: pointer;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  padding: 10px 20px;
+  text-decoration: none;
+  margin: 10px;
+}
+
+.btn-secondary:hover {
+  background-color: #0056b3;
+}
+.btn-secondary:disabled {
+  cursor: not-allowed;
+}
+
 .card {
   flex: 1;
   margin: 10px;
@@ -91,7 +112,30 @@ main {
 }
 .sort-filter {
   padding: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: .5rem;
+  flex-wrap: wrap;
 }
+
 .sort-button {
   margin: 5px;
+}
+
+.sort-order-select {
+  background-color: #363636;
+  border: 1px solid rgb(104, 104, 104);
+  border-radius: 8px;
+  color: white;
+  padding: 6px;
+  -webkit-appearance: button;
+  appearance: button;
+  outline: none;
+  cursor: pointer;
+}
+
+
+.sort-order-select option {
+  padding: 30px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ function App() {
   // Function to list repositories with Hacktoberfest tag
   const listHacktoberfestRepos = useCallback(
     async (tags, page) => {
+      setLoading(true);
       try {
         //  the query parameters
         const tagQuery =
@@ -109,18 +110,14 @@ function App() {
         </div>
         <div className="sort-filter">
           <span>Sort by Stars:</span>
-          <button
-            className={`sort-button ${sortOrder === "asc" ? "selected" : ""}`}
-            onClick={() => handleSortChange("asc")}
-          >
-            Ascending
-          </button>
-          <button
-            className={`sort-button ${sortOrder === "desc" ? "selected" : ""}`}
-            onClick={() => handleSortChange("desc")}
-          >
-            Descending
-          </button>
+         
+          <select className="sort-order-select" onChange={(e) => {
+            handleSortChange( (e.target.value) === "Ascending" ? "asc" : "desc" );
+          }}>
+            <option>Ascending</option>
+            <option>Descending</option>
+          </select>
+
         </div>
       </header>
       <main>
@@ -163,13 +160,15 @@ function App() {
                 </div>
               ))
             ) : (
+              (loading) ? 
+              <p>Searching for Repositories...</p> :
               <p>No repositories found.</p>
             )}
           </div>
           {/* Pagination controls */}
           <div className="pagination">
             {currentPage > 1 && (
-              <button className="btn btn-secondary" onClick={handlePrevPage}>
+              <button className="btn btn-secondary" onClick={handlePrevPage} disabled={loading}>
                 Previous
               </button>
             )}


### PR DESCRIPTION
I have addressed issue #2. The page will now show this instead of "No repositories found."

![loading](https://github.com/GDSC-FCRIT/fcrit-hacktoberfest/assets/82570809/6c152e47-cab2-42d1-994a-f73211be5044)


Also I have changed the style of order and next/previous buttons to match the rest of the website.

![me_top](https://github.com/GDSC-FCRIT/fcrit-hacktoberfest/assets/82570809/9101ddb3-552f-427e-be2b-33ef51a8a2c6)
![me_bottom](https://github.com/GDSC-FCRIT/fcrit-hacktoberfest/assets/82570809/ed3b961e-1ff6-4171-bbca-b0be95479ba8)

The next/previous buttons will also be disabled when a request is in progress to prevent spam clicking.